### PR TITLE
Create `Makefile`, add contribution instructions, improve autocomplete and help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: install update test
+
+install:
+	@scripts/mycli_setup.sh
+
+update:
+	@mycli update
+
+test:
+	@scripts/tests/run_tests.sh

--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@ Command-line interface (CLI) written in `bash`. This repository contains the min
 CLI. You can create your own CLI by copying the content, and replacing `mycli` and `bash-cli` with
 your command name.
 
+## Table of Contents
+
+- [bash-cli](#bash-cli)
+  - [Table of Contents](#table-of-contents)
+  - [Why bash?](#why-bash)
+  - [Design](#design)
+  - [Installation and update](#installation-and-update)
+    - [Setup](#setup)
+    - [Update](#update)
+  - [Using the CLI](#using-the-cli)
+    - [Autocomplete](#autocomplete)
+    - [Help commands](#help-commands)
+  - [Debug](#debug)
+  - [Contribute](#contribute)
+    - [Run tests locally](#run-tests-locally)
+  - [Troubleshoot](#troubleshoot)
+    - [Check the version of `bash`](#check-the-version-of-bash)
+    - [`zsh: command not found: mycli`](#zsh-command-not-found-mycli)
+
 ## Why bash?
 
 `bash` was chosen because it requires almost no setup, has a good ecosystem of commands, is good for
@@ -29,11 +48,14 @@ continue running when there are errors, the command may stop without error messa
    a Python `dict`, which is then converted into a Python string compatible with `bash`, so that the
    variables can be exported to be used by the `bash` script.
 
-## Setup
+## Installation and update
 
-Run: `scripts/mycli_setup.sh`
+### Setup
 
-This script will:
+1. Clone this repository.
+2. In the terminal, enter the `bash-cli` folder and run: `make install`
+
+This command will:
 
 - Install [Homebrew](https://brew.sh/)
 - Install commands with Homebrew
@@ -41,6 +63,14 @@ This script will:
   - Add the CLI to the `PATH` variable
   - Enable autocomplete for the CLI
 - Make the required scripts executable
+
+### Update
+
+To update `mycli`, you simply need to update the folder `bash-cli`. There are basically 3 ways:
+
+1. In the terminal, run: `mycli update`
+2. In the terminal, enter the `bash-cli` cloned folder and run: `make update`
+3. In the terminal, enter the `bash-cli` cloned folder and run: `git pull origin main`
 
 ## Using the CLI
 
@@ -66,7 +96,7 @@ mycli + TAB
 mycli <cmd1> + TAB
 ```
 
-Autocomplete is **not available** for the arguments of `mycli <cmd1> <cmd2>`.
+Autocomplete is **not available** for the arguments of `mycli <cmd1> <cmd2> + TAB`.
 
 ### Help commands
 
@@ -79,6 +109,7 @@ mycli help <cmd1>
 mycli <cmd1> --help
 mycli <cmd1> -h
 
+mycli help <cmd1> <cmd2>
 mycli <cmd1> <cmd2> --help
 mycli <cmd1> <cmd2> -h
 ```
@@ -91,6 +122,34 @@ mycli <cmd1> <cmd2> -h
   execution of the CLI and understanding its flow.
 - Or call the script directly, skipping the CLI: `CLI_DIR="path/to/bash-cli" ./commands/...`
   - For example: `CLI_DIR="path/to/bash-cli" ./commands/hello/world.sh 'John Doe'`
+
+## Contribute
+
+To contribute to `mycli`, make the desired modifications and run the tests (see the next session).
+When you make local changes, the modifications are applied locally without any additional step.
+
+If someone else wants to use the same modifications, they need to checkout to the new repository. No
+further action is required. For example, if you make changes in the remote branch `new-feature`, another
+person only needs to run `git fetch origin && git checkout new-feature`.
+
+For more details on code organization and content, check these files:
+
+- [README.md](README.md)
+- [commands/README.md](commands/README.md)
+- [core/README.md](core/README.md)
+- [core/cli_root/README.md](core/cli_root/README.md)
+- [core/helpers/README.md](core/helpers/README.md)
+- [scripts/doc_parser/README.md](scripts/doc_parser/README.md)
+- [scripts/doc_parser/docopt_ng/README.md](scripts/doc_parser/docopt_ng/README.md)
+
+### Run tests locally
+
+1. Run all tests: `make test`
+2. Run specific tests:
+   1. To run [ShellCheck](https://github.com/koalaman/shellcheck) (a static analysis tool for shell
+   scripts): `shellcheck --shell=bash /path/to/shell/file.sh`
+   2. To run unit tests with [shUnit2](https://github.com/kward/shunit2) (a unit test framework for
+   bash scripts), run a test file from the [tests](tests) folder. For example: `tests/core/test_helpers/test_echo.sh`
 
 ## Troubleshoot
 

--- a/commands/README.md
+++ b/commands/README.md
@@ -1,3 +1,4 @@
 # Commands
 
-This folder contains all CLI commands.
+This folder contains all CLI commands. The `commands` folder can contain subfolders with helper functions
+used only by that command.

--- a/commands/hello/world.sh
+++ b/commands/hello/world.sh
@@ -7,9 +7,9 @@ set -euo pipefail
 ##?   hello world [<name> --foo=NAMED_PARAM --some-flag -- <ls-args>...]
 ##?
 ##? Options:
-##?   --foo=NAMED_PARAM  Some named parameter [default: 42]
-##?   --some-flag        Some flag
-##?   <ls-args>          Arguments to pass to 'ls'
+##?   -f, --foo=NAMED_PARAM  Some named parameter [default: 42]
+##?   --some-flag            Some flag
+##?   <ls-args>              Arguments to pass to 'ls'
 ##?
 ##? Examples:
 ##?   hello world

--- a/core/cli_root/autocomplete.sh
+++ b/core/cli_root/autocomplete.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o pipefail
 
-_cli_completions() {
+_mycli_completions() {
   # Autocomplete function for the CLI.
   #
   # This function is called by the autocomplete system when the user presses the TAB key.
@@ -17,12 +17,15 @@ _cli_completions() {
 
   # Define possible completions for <cmd1>
   local -r cmds1=$(
-    find "$commands_dir" \
-      -maxdepth 1 \
-      -mindepth 1 \
-      -type d \
-      -exec basename {} \; |
-      sort
+    {
+      find "$commands_dir" \
+        -maxdepth 1 \
+        -mindepth 1 \
+        -type d \
+        -exec basename {} \;
+      echo "update"
+      echo "version"
+    } | sort
   )
 
   # Define possible completions for <cmd2>
@@ -53,4 +56,4 @@ _cli_completions() {
 }
 
 # Register the autocomplete function
-complete -F _cli_completions mycli
+complete -F _mycli_completions mycli

--- a/core/cli_root/cli_init.sh
+++ b/core/cli_root/cli_init.sh
@@ -10,6 +10,15 @@ run_command() {
     #   run_command <cmd1> <cmd2> [<cmd_args>...]
     #
     # Examples:
+    #
+    #   # Help:
+    #   run_command help hello
+    #   run_command hello --help
+    #   run_command hello -h
+    #   run_command help hello world
+    #   run_command hello world --help
+    #   run_command hello world -h
+    #
     #   run_command hello world
     #   run_command hel wor # if prefixes are unique, it is the same as: run_command hello world
     local -r cmd1=$1
@@ -18,9 +27,15 @@ run_command() {
     local -r cmd_args=("$@")
 
     if [[ $cmd1 == 'help' ]]; then
-        # mycli help <command>
-        list_commands "$cmd2" >&2
-        exit 0
+        if [[ ${#cmd_args[@]} -eq 0 ]]; then
+            # mycli help <command>
+            list_commands "$cmd2" >&2
+            exit 0
+        else
+            # mycli help <command> <subcommand>
+            run_command "$cmd2" "${cmd_args[@]}" --help
+            exit 0
+        fi
     elif [[ $cmd2 == '--help' || $cmd2 == '-h' ]]; then
         # mycli <command> --help
         # mycli <command> -h

--- a/scripts/doc_parser/docopt_ng/__init__.py
+++ b/scripts/doc_parser/docopt_ng/__init__.py
@@ -974,6 +974,14 @@ def convert_to_bash(parsed_options: ParsedOptions) -> str:
         else:
             value_bash: str = f'"{value}"'
 
+        if value_bash.startswith('"='):
+            # For example: hello world -f="value"
+            # `len(var_name_bash) == 1` cannot be used as additional condition, because `-f` could be an alias for
+            # something longer (e.g., `--foo`; in this case, `var_name_bash` would be "foo")
+            # The fix would be: `value_bash = f'"{value_bash[2::]}'`
+            show_log(f'WARNING: Found an argument with an equal sign for {key}: "{value}"\nYou may need to remove the '
+                     'equal sign from when calling the command.')
+
         bash_vars_definition.append(f'export {var_name_bash:s}={value_bash:s}')
 
     var_names_duplicates: list[str] = get_duplicate_vals(var_names_list)


### PR DESCRIPTION
## Description of changes

1. Create `Makefile`
2. Add Table of Contents to the README
3. Add more instructions to the README: using `make`, `mycli help <cmd1> <cmd2>`, contribution
4. Deal when using `mycli cmd1 cmd2 -x=value` (add warning). The expected is `mycli cmd1 cmd2 -x value`
5. Add `update` and `version` to the autocomplete of `mycli + TAB`
6. Add option to run `mycli help <cmd1> <cmd2>`
