### PR TITLE
Enable autocomplete for parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,8 @@ Examples:
 ```shell
 mycli + TAB
 mycli <cmd1> + TAB
+mycli <cmd1> + <cmd2> + TAB
 ```
-
-Autocomplete is **not available** for the arguments of `mycli <cmd1> <cmd2> + TAB`.
 
 ### Help commands
 

--- a/core/cli_root/autocomplete.sh
+++ b/core/cli_root/autocomplete.sh
@@ -1,6 +1,90 @@
 #!/usr/bin/env bash
 set -o pipefail
 
+_list_commands() {
+  # List all commands available in the CLI.
+  #
+  # Usage:
+  #   _list_commands <commands_dir>
+  #
+  # Examples:
+  #   _list_commands "$MYCLI_HOME/commands" # --> "hello update version"
+  local -r commands_dir="$1"
+
+  {
+    find "$commands_dir" \
+      -maxdepth 1 \
+      -mindepth 1 \
+      -type d \
+      -exec basename {} \;
+    echo "update"
+    echo "version"
+  } | sort
+}
+
+_list_subcommands() {
+  # List all subcommands available in the CLI.
+  #
+  # Usage:
+  #   _list_subcommands <commands_dir> <command>
+  #
+  # Examples:
+  #   _list_subcommands "$MYCLI_HOME/commands" "hello" # --> "world"
+  local -r commands_dir="$1"
+  local -r command="$2"
+
+  # Part of this code is the same as the CLI function `list_commands`
+  find "$commands_dir" \
+    -mindepth 2 \
+    -maxdepth 2 \
+    -type f \
+    -path "${commands_dir}/${command}*/*" \
+    -name "*.sh" \
+    -exec basename {} \; |
+    sed "s:\.sh$::" |
+    sort
+}
+
+_extract_arguments() {
+  # Extract the arguments from the help message of a command. The help content must follow the
+  # docopt format.
+  #
+  # Usage:
+  #   _extract_arguments <cmd1> <cmd2>
+  #
+  # Examples:
+  #   _extract_arguments "hello" "world" # --> "--foo --help --some-flag"
+  local -r cmd1="$1"
+  local -r cmd2="$2"
+
+  # Extract help message
+  local -r help=$(mycli "$cmd1" "$cmd2" --help)
+
+  # Extract usage from the help message
+  local -r docopt_usage=$(echo "$help" | sed -n '/^usage:/I,/^$/p' | sed '$d')
+  local -r usage_line=$(echo "$docopt_usage" | grep "^ *$cmd1  *$cmd2 " || :)
+
+  params=""
+
+  # Extract parameters from the "Options" section when "[options]" is declared in the usage line
+  if grep -q '\[options\]' <<<"$usage_line"; then
+    local -r docopt_options=$(echo "$help" | sed -n '/^options:/I,/^$/p' | sed '$d')
+  else
+    local -r docopt_options=""
+  fi
+
+  # Extract parameters from the usage line
+  # - get the parameters that start with a dash, delimited by space, equal sign and comma: "--foo --foo=42" or
+  #   "-f, --foo" (only appears in the options)
+  # - exclude the 'parameter' "--" and parameters such as "<ls-args>"
+  params+=$(echo "$usage_line $docopt_options" |
+    grep -o -- '-[^ =,]*' |
+    grep -vE '^--$|>' || :)
+
+  # Add "--help" because it's always available and is normally not declared in the usage line
+  echo -e "$params\n--help" | sort -u
+}
+
 _mycli_completions() {
   # Autocomplete function for the CLI.
   #
@@ -15,42 +99,34 @@ _mycli_completions() {
     return 0
   fi
 
-  # Define possible completions for <cmd1>
-  local -r cmds1=$(
-    {
-      find "$commands_dir" \
-        -maxdepth 1 \
-        -mindepth 1 \
-        -type d \
-        -exec basename {} \;
-      echo "update"
-      echo "version"
-    } | sort
-  )
-
-  # Define possible completions for <cmd2>
-  # The code is the same as the CLI function `list_commands`
-  local -r cmds2=$(
-    find "$commands_dir" \
-      -mindepth 2 \
-      -maxdepth 2 \
-      -type f \
-      -path "${commands_dir}/${prev}*/*" \
-      -name "*.sh" \
-      -exec basename {} \; |
-      sed "s:\.sh$::" |
-      sort
-  )
-
-  # If the user is completing <cmd1> (the first argument)
-  if [[ ${COMP_CWORD} -eq 1 ]]; then
+  # Case 1: The user is completing <cmd1> (the first argument)
+  if [[ $COMP_CWORD -eq 1 ]]; then
+    # Define possible completions for <cmd1>
+    local -r cmds1=$(_list_commands "$commands_dir")
     # shellcheck disable=SC2207
     COMPREPLY=($(compgen -W "$cmds1" -- "$cur"))
     return 0
-  # If the user is completing <cmd2> (the second argument)
-  elif [[ ${COMP_CWORD} -eq 2 ]]; then
+
+  # Case 2: The user is completing <cmd2> (the second argument)
+  elif [[ $COMP_CWORD -eq 2 ]]; then
+    # Define possible completions for <cmd2>
+    local -r cmds2=$(_list_subcommands "$commands_dir" "$prev")
     # shellcheck disable=SC2207
     COMPREPLY=($(compgen -W "$cmds2" -- "$cur"))
+    return 0
+
+  # Case 3: The user is completing the parameters
+  else
+    local args
+    args="$(_extract_arguments "${COMP_WORDS[1]}" "${COMP_WORDS[2]}")"
+
+    # Remove arguments that were already typed by the user
+    for ((i = 3; i < COMP_CWORD; i++)); do
+      args=$(grep -v "^${COMP_WORDS[i]}" <<<"$args")
+    done
+
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -W "$args" -- "$cur"))
     return 0
   fi
 }

--- a/core/cli_root/cli_init.sh
+++ b/core/cli_root/cli_init.sh
@@ -55,7 +55,7 @@ run_command() {
     local -r color_blue='\x1b[34m'
 
     if [[ -z $command_path ]]; then
-        # The commmand was not found.
+        # The command was not found.
         local -r asterisk="${color_blue}*${no_color}"
         echo >&2 -e "${color_red}ERROR:${no_color} It was not possible to find the command '${cmd1} ${cmd2}'."
         echo >&2 -e "       Make sure that the following path exists: '${commands_dir}/${cmd1}${asterisk}/${cmd2}${asterisk}.sh'"


### PR DESCRIPTION
New autocomplete for parameters: `mycli <cmd1> <cmd2> + tab`

- They are suggested in alphabetical order.
- If parameters already appeared in the command-line, they are not suggested in the autocomplete.

Examples:

![Screenshot 2024-12-15 at 16 39 41](https://github.com/user-attachments/assets/39e4ef8f-95f3-4554-9041-e3f622d0dce7)
![Screenshot 2024-12-15 at 16 39 52](https://github.com/user-attachments/assets/0b5974ae-2970-4ed2-a1d8-026361c57ec0)
