### PR TITLE
Improve autocomplete

### DIFF
--- a/commands/files/README.md
+++ b/commands/files/README.md
@@ -1,0 +1,3 @@
+# `mycli files`
+
+Deal with files

--- a/commands/hello/README.md
+++ b/commands/hello/README.md
@@ -1,0 +1,3 @@
+# `mycli hello`
+
+Commands used to test the CLI

--- a/commands/python/README.md
+++ b/commands/python/README.md
@@ -1,0 +1,3 @@
+# `mycli python`
+
+Python commands

--- a/core/cli_root/autocomplete.zsh
+++ b/core/cli_root/autocomplete.zsh
@@ -22,11 +22,13 @@ _mycli_completions() {
   if ((CURRENT == 2)); then
     # Define possible completions for <cmd1>
 
-    # shellcheck disable=SC2034,SC2207
-    local -ra cmds1=($(_mycli_list_commands "$commands_dir"))
+    local -r cmds_descriptions=$(_mycli_list_commands_and_description "$commands_dir")
+
+    # Convert the multiline string to an array
+    local -ra cmds_descriptions_array=("${(f)cmds_descriptions}")
     # shellcheck disable=SC2207
     # compadd -X "Available commands:" -a cmds1
-    _describe 'mycli commands' cmds1
+    _describe 'mycli commands' cmds_descriptions_array
     return 0
 
   # Case 2: The user is completing <cmd2> (the second argument)
@@ -61,9 +63,14 @@ _mycli_completions() {
       return 0
     fi
 
+    local -r args_parameters=$(echo "$args_with_description" | grep '^-')
+    local -r args_actions=$(echo "$args_with_description" | grep -v '^-')
+
     # Convert the multiline string to an array
-    local -ra args_with_description_array=("${(f)args_with_description}")
-    _describe 'mycli parameters' args_with_description_array
+    local -ra args_parameters_array=("${(f)args_parameters}")
+    local -ra args_actions_array=("${(f)args_actions}")
+    _describe -t params 'mycli parameters' args_parameters_array
+    _describe -t actions 'mycli actions' args_actions_array
     return 0
   fi
 }

--- a/core/cli_root/autocomplete_helpers.sh
+++ b/core/cli_root/autocomplete_helpers.sh
@@ -160,6 +160,33 @@ _mycli_extract_arguments() {
 # Functions for zsh only
 # ==================================================================================================
 
+_mycli_list_commands_and_description() {
+  # List all commands and their descriptions available in the CLI.
+  #
+  # Usage:
+  #   _mycli_list_commands_and_description <commands_dir>
+  #
+  # Examples:
+  #   _mycli_list_commands_and_description "$MYCLI_HOME/commands" # --> "hello:Say hello\nupdate:Update mycli\nversion:Show mycli version"
+  local -r commands_dir=$1
+
+  find "$commands_dir" \
+    -maxdepth 1 \
+    -mindepth 1 \
+    -type d \
+    -exec basename {} \; | while read -r command; do
+    if [[ -s "$commands_dir/$command/README.md" ]]; then
+      # first non-empty line not starting with "#" in the README file
+      description=$(grep -m 1 -vE '^#|^[[:space:]]*$' "$commands_dir/$command/README.md")
+    else
+      description="<no description>"
+    fi
+    echo "$command:$description"
+  done
+  echo "update:Update mycli"
+  echo "version:Show mycli version"
+}
+
 _mycli_list_subcommands_and_description() {
   # List all subcommands and their descriptions available in the CLI.
   #

--- a/core/helpers/files.sh
+++ b/core/helpers/files.sh
@@ -49,6 +49,7 @@ find_relevant_files() {
         -not -name '*.tfstate.backup' \
         -not -name '*.coverage' \
         -not -path '*/.git/*' \
+        -not -name '.gitkeep' \
         -not -path '*/.idea/*' \
         -not -path '*/.terraform/*' \
         "${find_args[@]}" #\

--- a/scripts/tests/test_docs.sh
+++ b/scripts/tests/test_docs.sh
@@ -20,14 +20,45 @@ source "${TESTS_DIR}/unit_test_helpers.sh"
 # --------------------------------------------------------------------------------------------------
 
 if [ -z "$command_files" ]; then
+  test_all_commands=true
   command_files=$(get_all_command_files "$CLI_DIR")
+else
+  test_all_commands=false
 fi
+
+command_files=$(echo "$command_files" | sort)
 
 echo "Validations:"
 echo "1. The documentation lines must start with '##?' followed by a space."
 echo "2. The 'Usage' section must start with the command name (use additional indentation to split the line)."
 echo "3. The 'Options' section must be present if '[options]' is declared in the 'Usage' section."
 echo "4. The '--help' parameter must be declared in the 'Options' section if there is another parameter called '--help...'."
+echo "5. The length of the lines related to the descriptions of commands, subcommands and options must be less than 150 characters."
+echo
+
+commands_path=$(echo "$command_files" | head -n1 | sed -E 's:(.*)/commands/[^/]+/[^/]+\.sh:\1/commands:')
+commands_description=$(_mycli_list_commands_and_description "$commands_path")
+
+if $test_all_commands; then
+  commands_in_path=$(echo "$command_files" | sed -E "s:$commands_path/::" | cut -d/ -f1 | sort -u)
+  if ! [[ "$commands_in_path" == "$(echo "$commands_description" | cut -d':' -f1 | sed -E '/^(update|version)$/d' | sort)" ]]; then
+    echo "[ERROR] The list of commands in the 'commands' path is different from the list of commands with descriptions."
+    echo "Commands in the path '$commands_path':"
+    echo "$commands_in_path"
+    echo ""
+    echo "Commands with descriptions:"
+    echo "$commands_description" | sed -E '/^(update|version):/d' | sort
+    exit 1
+  fi
+fi
+
+if long_lines=$(grep -E '^.{151,}' <<<"$commands_description"); then
+  echo "[ERROR] The length of the command name + description must be less than 150 characters. Violations:"
+  echo "$long_lines" | sort
+  exit 1
+fi
+
+prev_command_name=""
 
 while IFS= read -r command_file; do
   command_file_relative_path="${command_file#"$CLI_DIR"/}" # remove the base path and leading '/'
@@ -73,4 +104,39 @@ while IFS= read -r command_file; do
     #   exit 1
     # fi
   fi
+
+  command_name=$(echo "$command_file" | sed -E "s:$commands_path/::" | cut -d/ -f1)
+  if [[ "$command_name" != "$prev_command_name" ]]; then
+    prev_command_name="$command_name"
+    subcommands=$(_mycli_list_subcommands "$commands_path" "$command_name")
+    subcommands_description=$(_mycli_list_subcommands_and_description "$commands_path" "$command_name")
+
+    if $test_all_commands; then
+      if ! [[ "$(echo "$subcommands" | sort)" == "$(echo "$subcommands_description" | cut -d':' -f1 | sort)" ]]; then
+        echo "[ERROR] The list of subcommands in the 'commands' directory is different from the list of subcommands with descriptions."
+        echo "Subcommands in the path '$commands_path':"
+        echo "$subcommands" | sort
+        echo ""
+        echo "Subcommands with descriptions:"
+        echo "$subcommands_description" | sort
+        exit 1
+      fi
+    fi
+
+    if long_lines=$(grep -E '^.{151,}' <<<"$subcommands_description"); then
+      echo "[ERROR] The length of the subcommand name + description must be less than 150 characters."
+      echo "Offending lines for subcommands in command '$command_name':"
+      echo "$long_lines" | sort
+      exit 1
+    fi
+  fi
+
+  all_args_with_description=$(_mycli_extract_arguments_with_descriptions "$help" "$cmd1" "$cmd2")
+  if long_lines=$(grep -E '^.{151,}' <<<"$all_args_with_description" | grep -v '^:'); then
+    echo "[ERROR] The length of the options descriptions must be less than 150 characters."
+    echo "Offending lines in command '$command_file_relative_path':"
+    echo "$long_lines"
+    exit 1
+  fi
+
 done <<<"$command_files"

--- a/tests/core/cli_root/test_autocomplete_helpers.sh
+++ b/tests/core/cli_root/test_autocomplete_helpers.sh
@@ -11,6 +11,7 @@ test__mycli_list_commands() {
   result=$(_mycli_list_commands "$TEST_COMMANDS_PATH" | sort)
   expected=$(
     cat <<-EOF
+	foo
 	hello
 	update
 	update
@@ -87,7 +88,8 @@ EOF
 test__mycli_extract_parameters() {
   local result expected usage
 
-  usage=$(cat <<-EOF
+  usage=$(
+    cat <<-EOF
 	foo bar baz -q --v --qwe=1 --qwe-rty <some-param> -- [--some-param=<x> --my-flag]
 	-f FILE  File name
 	--some_param=FILE_NAME  Some parameter
@@ -193,6 +195,25 @@ EOF
 # ==================================================================================================
 # Functions for zsh only
 # ==================================================================================================
+
+test__mycli_list_commands_and_description() {
+  local result expected
+
+  result=$(
+    _mycli_list_commands_and_description "$TEST_COMMANDS_PATH" |
+      sort |
+      sed 's/^update:<no description>$// ; /^ *$/d' # remove the "update" command, because the folder exists for other unit tests
+  )
+  expected=$(
+    cat <<-EOF
+	foo:<no description>
+	hello:Commands used to test the CLI in the test folder
+	update:Update mycli
+	version:Show mycli version
+EOF
+  )
+  assertEquals "$expected" "$result"
+}
 
 test__mycli_list_subcommands_and_description() {
   local result expected

--- a/tests/core/helpers/test_files.sh
+++ b/tests/core/helpers/test_files.sh
@@ -18,10 +18,10 @@ test_find_relevant_files() {
 
     result=$(find_relevant_files "tests/resources/commands" | sort)
     expected=$(cat <<-EOF
+	tests/resources/commands/hello/README.md
 	tests/resources/commands/hello/hello-world.sh
 	tests/resources/commands/no_newline_at_the_end.txt
 	tests/resources/commands/problematic file.sh
-	tests/resources/commands/update/.gitkeep
 EOF
     )
     assertEquals "$expected" "$result"

--- a/tests/resources/commands/hello/README.md
+++ b/tests/resources/commands/hello/README.md
@@ -1,0 +1,3 @@
+# `mycli hello`
+
+Commands used to test the CLI in the test folder


### PR DESCRIPTION
## Description of changes

- Add descriptions to the commands `mycli <command>` when autocompleting `mycli + TAB`
- Separate the autocomplete group of parameters into `mycli parameters` and `mycli actions`
- Add more tests to the commands docs: they should be parsed, and descriptions can't be too long
- Unrelated change: ignore file `.gitkeep` in the list of relevant files

## Screenshots

- Autocompleting `mycli + TAB`
    <img width="352" alt="Screenshot 2025-02-01 at 09 41 41" src="https://github.com/user-attachments/assets/e38cf061-2265-412a-9eda-91c2fdcf0884" />
- Autocompleting `mycli + <cmd> + TAB`
    <img width="391" alt="Screenshot 2025-02-01 at 09 42 46" src="https://github.com/user-attachments/assets/581cbd03-6152-4355-afeb-c32b3d1c9e80" />
- Autocompleting `mycli + <cmd1> + <cmd2> + TAB`
    <img width="527" alt="Screenshot 2025-02-01 at 09 43 56" src="https://github.com/user-attachments/assets/1e014753-74f0-403d-b21c-b343d84eb91d" />
