### PR TITLE
Add functionality to run Python scripts

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,13 +25,16 @@ jobs:
         set -euo pipefail
 
         modified_files=$(git diff --diff-filter=d --name-only HEAD^ HEAD)
-        echo "$(echo "$modified_files" | wc -l | awk '{print $1}') modified file(s) (excluding deleted files; showing at most 20):"
+        number_modified_files=$(echo "$modified_files" | wc -l | awk '{print $1}')
+        echo "$number_modified_files modified file(s) (excluding deleted files)"
+        echo "--------------------- Modified files (showing at most 20) ----------------------"
         echo "$modified_files" | sort | head -n 20
         echo "--------------------------------------------------------------------------------"
-
-        echo 'Install uv'
+        echo
+        echo "---------------------------------- Install uv ----------------------------------"
         curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo 'Done!'
+        echo "--------------------------------------------------------------------------------"
+        echo
 
         # TODO: Run tests only for modified files
         ./scripts/tests/run_all_tests.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,5 +29,9 @@ jobs:
         echo "$modified_files" | sort | head -n 20
         echo "--------------------------------------------------------------------------------"
 
+        echo 'Install uv'
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo 'Done!'
+
         # TODO: Run tests only for modified files
         ./scripts/tests/run_all_tests.sh

--- a/commands/hello/python-script.sh
+++ b/commands/hello/python-script.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+##? Run Python script.
+##?
+##? Usage:
+##?   hello python-script [<name> --foo=NAMED_PARAM --some-flag -- <extra-args>...]
+##?
+##? Options:
+##?   -f, --foo=NAMED_PARAM  Some named parameter [default: 42]
+##?   --some-flag            Some flag
+##?   <extra-args>           Extra arguments to pass to the Python script
+##?
+##? Examples:
+##?   hello python-script
+##?   hello python-script John
+##?   hello python-script 'John Doe'
+##?   hello python-script --foo=37 --some-flag
+##?
+##?   # Passing extra arguments
+##?   hello python-script Jane -- -l -a
+
+source "${CLI_DIR}/core/helpers.sh"
+parse_help "$@"
+declare foo name some_flag
+declare -a extra_args
+
+current_dir="$(get_dir_name "${BASH_SOURCE[0]}")"
+
+echo "Running Python script..."
+run_python_script "$current_dir/script.py" --foo="$foo" --some-flag="$some_flag" "$name" "${extra_args[@]}"
+echo_done

--- a/commands/hello/script.py
+++ b/commands/hello/script.py
@@ -1,0 +1,48 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# [tool.uv]
+# exclude-newer = "2025-01-31T23:59:59Z"
+# ///
+
+import argparse
+import sys
+
+
+def add(a: int | None, b: int | None) -> int | None:
+    if a is None or b is None:
+        return None
+    return a + b
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Prints a greeting.")
+    parser.add_argument("name", type=str, help="The name to greet.")
+    parser.add_argument("--foo", type=str, help="Some named parameter")
+    parser.add_argument("--some-flag", type=str, help="Some flag")
+
+    # args: argparse.Namespace = parser.parse_args()
+    args, extra_args = parser.parse_known_args()
+
+    name: str = args.name
+    foo: str = args.foo
+    some_flag: bool = True if args.some_flag == "true" else False
+
+    print("Hello from the Python script!")
+    print()
+    print(f"Python version: {sys.version}")
+    print()
+    print("Received arguments:")
+    print(" ".join(sys.argv[1:]))
+    print()
+    print("Parsed arguments:")
+    print(f"- name='{name}'")
+    print(f"  type(name)='{type(name).__name__}'")
+    print(f"- foo='{foo}'")
+    print(f"  type(foo)='{type(foo).__name__}'")
+    print(f"- some_flag='{some_flag}'")
+    print(f"  type(some_flag)='{type(some_flag).__name__}'")
+    print()
+    print("Additional arguments:")
+    print(f"- {extra_args}")
+    print(f"  type(extra_args)='{type(extra_args).__name__}'")

--- a/core/helpers/python.sh
+++ b/core/helpers/python.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_python_script() {
+  # Run a Python script with the given arguments.
+  #
+  # The Python version and dependencies are defined by the script metadata [1,2,3].
+  #
+  # Usage:
+  #   run_python_script <python_script> [<script_args>...]
+  #
+  # References:
+  # [1] https://packaging.python.org/en/latest/specifications/inline-script-metadata/
+  # [2] https://peps.python.org/pep-0723/
+  # [3] https://docs.astral.sh/uv/guides/scripts/#creating-a-python-script
+  #
+  # Examples:
+  #   run_python_script "my/python/script.py" "foo" "--bar=42" "--some-flag"
+  local -r python_script=$1
+  shift 1
+  local -r script_args=("$@")
+
+  uv run "$python_script" "${script_args[@]}"
+}

--- a/scripts/mycli_setup.sh
+++ b/scripts/mycli_setup.sh
@@ -54,7 +54,7 @@ fi
 # --------------------------------------------------------------------------------------------------
 
 show_section "Install the required commands"
-brew install bash coreutils findutils gawk gnu-sed grep jq shellcheck sponge wget
+brew install bash coreutils findutils gawk gnu-sed grep jq shellcheck sponge uv wget
 show_done
 
 # Edit the PATH variable

--- a/scripts/tests/run_all_tests.sh
+++ b/scripts/tests/run_all_tests.sh
@@ -68,8 +68,12 @@ invalid_files_lines_at_the_end=$(remove_from_list "$invalid_files_lines_at_the_e
 check_if_error "$invalid_files_lines_at_the_end"
 echo_done
 
-new_section "All commands should have a correct documentation"
+new_section "All commands should have correct documentation"
 "${CUR_DIR}/test_docs.sh"
+echo_done
+
+new_section "Run Python tests"
+"${CUR_DIR}/test_python.sh"
 echo_done
 
 new_section "Run ShellCheck, a static analysis tool for shell scripts"

--- a/scripts/tests/test_python.sh
+++ b/scripts/tests/test_python.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   test_python.sh [<python_scripts>]
+
+# Initialize
+# --------------------------------------------------------------------------------------------------
+
+python_scripts=${1:-}
+
+CUR_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+CLI_DIR=$(realpath "${CUR_DIR}/../..")
+TESTS_DIR="${CLI_DIR}/tests"
+
+source "${TESTS_DIR}/unit_test_helpers.sh"
+
+# Run tests
+# --------------------------------------------------------------------------------------------------
+
+if [ -z "$python_scripts" ]; then
+  python_scripts=$(find "$CLI_DIR/commands" -type f -name '*.py')
+  # Maybe filter for files containing `if __name__ == "__main__":`. In this case, create a helper
+  # function in file `tests/unit_test_helpers.sh`.
+fi
+
+new_section_level_2 "All Python scripts should have metadata (PEP 723)"
+# https://packaging.python.org/en/latest/specifications/inline-script-metadata/
+# Only scripts called after the pattern `^[^#]*run_python_script ` should be verified, but it may not
+# be easy to find the name of the script, because it may be defined by a variable or a function.
+invalid_files_metadata=''
+total_files=$(echo "$python_scripts" | wc -l | xargs)
+if [ "$total_files" -eq 1 ]; then plural=''; else plural='s'; fi
+echo "Checking $total_files Python file$plural..."
+while IFS= read -r python_script; do
+  if ! python3 "$TESTS_DIR/python/read_script_metadata.py" "$python_script" >/dev/null; then
+    echo
+    invalid_files_metadata+="\n$python_script"
+  fi
+done <<<"$python_scripts"
+check_if_error "$invalid_files_metadata"
+
+new_section_level_2 "Run unit tests for Python scripts with pytest"
+if command -v uv >/dev/null; then
+  uv run --with 'pytest>=8,<9' -- python3 -m pytest tests/python
+else
+  venv_name=".venv_pytest"
+  python3 -m venv "$venv_name"
+  source "$venv_name/bin/activate"
+  echo
+  echo 'Installing pytest...'
+  python3 -m pip install 'pytest>=8,<9'
+  echo
+  echo 'Running tests...'
+  python3 -m pytest tests/python
+fi

--- a/tests/core/helpers/test_files.sh
+++ b/tests/core/helpers/test_files.sh
@@ -16,20 +16,18 @@ test_backup_if_exists() {
 test_find_relevant_files() {
     local result expected
 
-    result=$(find_relevant_files "tests/resources/commands" | sort)
+    result=$(find_relevant_files "tests/resources/commands/hello" | sort)
     expected=$(cat <<-EOF
 	tests/resources/commands/hello/README.md
 	tests/resources/commands/hello/hello-world.sh
-	tests/resources/commands/no_newline_at_the_end.txt
-	tests/resources/commands/problematic file.sh
+	tests/resources/commands/hello/script.py
 EOF
     )
     assertEquals "$expected" "$result"
 
-    result=$(find_relevant_files "tests/resources/commands" -name '*.sh' | sort)
+    result=$(find_relevant_files "tests/resources/commands/hello" -name '*.sh' | sort)
     expected=$(cat <<-EOF
 	tests/resources/commands/hello/hello-world.sh
-	tests/resources/commands/problematic file.sh
 EOF
     )
     assertEquals "$expected" "$result"

--- a/tests/core/helpers/test_python.sh
+++ b/tests/core/helpers/test_python.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_run_python_script() {
+    local result expected
+
+    result=$(
+        run_python_script \
+            "tests/resources/commands/hello/script.py" \
+            "--some-int=42" "--some-flag"
+    )
+    expected="some_int='42', some_flag='True'"
+    assertEquals "$expected" "$result"
+
+    result=$(
+        run_python_script \
+            "tests/python/read_script_metadata.py" \
+            "tests/resources/commands/hello/script.py"
+    )
+    expected="{'requires-python': '>=3.12', 'dependencies': [], 'tool': {'uv': {'exclude-newer': '2001-12-31T23:59:59Z'}}}"
+    assertEquals \
+        "Test the behavior of the script 'read_script_metadata.py'" \
+        "$expected" \
+        "$result"
+}
+
+oneTimeSetUp() {
+    . core/helpers/python.sh
+}
+
+. scripts/shunit2

--- a/tests/python/commands/hello/test_script.py
+++ b/tests/python/commands/hello/test_script.py
@@ -1,0 +1,14 @@
+from pytest import mark
+import commands.hello.script as hello_script
+
+
+@mark.parametrize("a, b, expected", [
+    (1, 2, 3),
+    (-2, 3, 1),
+    (None, 99, None),
+    (101, None, None),
+    (None, None, None),
+])
+def test_add(a, b, expected):
+    result: int | None = hello_script.add(a, b)
+    assert result == expected

--- a/tests/python/read_script_metadata.py
+++ b/tests/python/read_script_metadata.py
@@ -1,0 +1,37 @@
+# Source:
+# https://packaging.python.org/en/latest/specifications/inline-script-metadata/#reference-implementation
+
+import re
+import tomllib
+import sys
+
+REGEX: str = r'(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$'
+
+
+def read(script: str) -> dict | None:
+    name: str = 'script'
+    matches = list(filter(lambda m: m.group('type') == name, re.finditer(REGEX, script)))
+    if len(matches) > 1:
+        # raise ValueError(f'Multiple {name:s} blocks found: {matches}')
+        # To avoid showing the full stack trace:
+        print(f'Multiple {name:s} blocks found: {matches}', file=sys.stderr)
+        sys.exit(1)
+    elif len(matches) == 1:
+        content: str = ''.join(
+            line[2:] if line.startswith('# ') else line[1:]
+            for line in matches[0].group('content').splitlines(keepends=True)
+        )
+        return tomllib.loads(content)
+    else:
+        return None
+
+
+if __name__ == '__main__':
+    filename: str = sys.argv[1]
+    with open(filename, 'r') as file:
+        script: str = file.read()
+    metadata: dict | None = read(script)
+    if metadata is not None:
+        print(metadata)
+    else:
+        print('No metadata found.')

--- a/tests/resources/commands/hello/script.py
+++ b/tests/resources/commands/hello/script.py
@@ -1,0 +1,21 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# [tool.uv]
+# exclude-newer = "2001-12-31T23:59:59Z"
+# ///
+
+import argparse
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Test script.")
+    parser.add_argument("--some-int", type=int, help="Some number")
+    parser.add_argument("--some-flag", action='store_true', help="Some flag")
+
+    args: argparse.Namespace = parser.parse_args()
+
+    some_int: int = args.some_int
+    some_flag: bool = args.some_flag
+
+    print(f"some_int='{some_int}', some_flag='{some_flag}'")

--- a/tests/unit_test_helpers.sh
+++ b/tests/unit_test_helpers.sh
@@ -79,6 +79,7 @@ get_all_files() {
         -type f \
         -not -path '*/.git/*' \
         -not -path '*/.pytest_cache/*' \
+        -not -path '*/.venv*/*' \
         -not -name '*.pyc' \
         -not -name '.DS_Store'
 }


### PR DESCRIPTION
We will use `uv` (https://docs.astral.sh/uv/guides/scripts/), because it's fast, modern, accepts [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/), and allows to choose the Python version and dependencies.