### PR TITLE
create shell_file if missing

### DIFF
--- a/scripts/mycli_setup.sh
+++ b/scripts/mycli_setup.sh
@@ -77,6 +77,8 @@ for shell_file in "${shell_files[@]}"; do
     echo "'$shell_file' already exists. Backup created: '$backup_path'"
   fi
 
+  touch "$shell_file"
+
   echo -n "Removing multiple empty lines and the section between '$start_pattern' and '$end_pattern' in file '$shell_file'... "
   sed -e "/^[[:space:]]*$/N;/^\n[[:space:]]*$/D" -e "/^[[:space:]]*$start_pattern/,/$end_pattern/d" "$shell_file" | sponge "$shell_file"
   show_done


### PR DESCRIPTION
## Background context

As described in the [issue 35](https://github.com/gcbeltramini/bash-cli/issues/35), if there is no `.bash_profile` file, the code will fail.

## Description of changes

Added a `touch` that will create a file if missing, and not change to the file content is made if the file already exists.

## Related pull requests or issues

https://github.com/gcbeltramini/bash-cli/issues/35

