### PR TITLE
Treat case when there are multiple matching commands when running `mycli <cmd>`

### DIFF
--- a/core/cli_root/autocomplete_helpers.sh
+++ b/core/cli_root/autocomplete_helpers.sh
@@ -254,7 +254,7 @@ _mycli_get_arg_description() {
   local line_number
 
   # Remove parameters that start with "<" (must be consistent with the function `_mycli_get_args_description`)
-  local -r docopt_options=$(echo "$docopt_options_raw" | grep -vE '^[[:space:]]*<')
+  local -r docopt_options=$(echo "$docopt_options_raw" | grep -vE '^[[:space:]]*<' || :)
 
   # Remove lines with more than 5 leading spaces (description lines). This must be consistent with
   # the function `_mycli_extract_parameter_names`.
@@ -283,7 +283,7 @@ _mycli_get_args_description() {
   local -r description_fallback="<no description>"
 
   # Remove parameters that start with "<" (must be consistent with the function `_mycli_get_arg_description`)
-  local -r docopt_options=$(echo "$docopt_options_raw" | grep -vE '^[[:space:]]*<')
+  local -r docopt_options=$(echo "$docopt_options_raw" | grep -vE '^[[:space:]]*<' || :)
 
   local -r options_without_descriptions=$(_mycli_extract_parameter_names "$docopt_options")
 

--- a/core/cli_root/cli_init.sh
+++ b/core/cli_root/cli_init.sh
@@ -125,21 +125,23 @@ list_commands() {
       echo -e "update\t-- $update_description"
       echo -e "version\t-- $version_description"
     } | sort | column -t -s $'\t'
-  else
-    if [[ $cmd == "update" ]]; then
-      cat <<-EOF
-	$update_description
+    return 0
+  fi
 
-	Usage:
-	  mycli update
+  if [[ $cmd == "update" ]]; then
+    cat <<-EOF
+$update_description
+
+Usage:
+  mycli update
 EOF
-      return 0
-    elif [[ $cmd == "version" ]]; then
-      cat <<-EOF
-	$version_description
+    return 0
+  elif [[ $cmd == "version" ]]; then
+    cat <<-EOF
+$version_description
 
-	Usage:
-	  mycli version
+Usage:
+  mycli version
 EOF
       return 0
     fi

--- a/core/cli_root/cli_init.sh
+++ b/core/cli_root/cli_init.sh
@@ -11,7 +11,7 @@ print_error() {
   local -r message=$1
   local -r no_color='\x1b[0m'
   local -r color_red='\x1b[31m'
-  echo >&2 -e "${color_red}ERROR:${no_color} ${message}"
+  printf >&2 '%bERROR:%b %s\n' "$color_red" "$no_color" "$message"
 }
 
 run_command() {

--- a/core/cli_root/cli_init.sh
+++ b/core/cli_root/cli_init.sh
@@ -181,6 +181,7 @@ EOF
   echo "Available commands for '$full_cmd'"
   local -r dashes=$(printf '%*s' "${#full_cmd}" '' | tr ' ' '-')
   echo "-------------------------${dashes}"
+  local subcommand description
   find "$commands_dir" \
     -mindepth 2 \
     -maxdepth 2 \

--- a/core/cli_root/cli_init.sh
+++ b/core/cli_root/cli_init.sh
@@ -147,7 +147,7 @@ EOF
   fi
 
   # Find matching command directories
-  local -r matching_dirs=$(find "$commands_dir" -maxdepth 1 -type d -name "${cmd}*" 2>/dev/null)
+  local -r matching_dirs=$(find "$commands_dir" -mindepth 1 -maxdepth 1 -type d -name "${cmd}*" 2>/dev/null)
   local -r matching_count=$(echo "$matching_dirs" | wc -l | awk '{print $1}')
   local -r matching_dir_exact=$(echo "$matching_dirs" | grep "/${cmd}$" || :)
 

--- a/core/cli_root/cli_init.sh
+++ b/core/cli_root/cli_init.sh
@@ -143,24 +143,47 @@ $version_description
 Usage:
   mycli version
 EOF
-      return 0
-    fi
-
-    echo "Available commands for '$cmd'"
-    local -r dashes=$(printf '%*s' "${#cmd}" '' | tr ' ' '-')
-    echo "-------------------------${dashes}"
-    find "$commands_dir" \
-      -mindepth 2 \
-      -maxdepth 2 \
-      -type f \
-      -path "${commands_dir}/${cmd}*/*" \
-      -name "*.sh" | while read -r command_file; do
-      subcommand=$(echo "$command_file" | awk -F/ '{print $NF}' | sed 's/\.sh$//')
-      # first line starting with "##?":
-      description=$(grep -m 1 '^##?' "$command_file" | sed 's/^##? *//')
-      echo -e "$subcommand\t-- $description"
-    done | sort | column -t -s $'\t'
+    return 0
   fi
+
+  # Find matching command directories
+  local -r matching_dirs=$(find "$commands_dir" -maxdepth 1 -type d -name "${cmd}*" 2>/dev/null)
+  local -r matching_count=$(echo "$matching_dirs" | wc -l | awk '{print $1}')
+  local -r matching_dir_exact=$(echo "$matching_dirs" | grep "/${cmd}$" || :)
+
+  if [[ $matching_count -eq 0 || -z $matching_dirs ]]; then
+    # No matching command
+    print_error "Command '$cmd' not found."
+    return 1
+  elif [[ $matching_count -gt 1 && -z $matching_dir_exact ]]; then
+    # Multiple matching commands
+    print_error "It was not possible to distinguish the commands."
+    echo >&2
+    echo >&2 "Multiple matches found"
+    echo >&2 "----------------------"
+    echo "$matching_dirs" | while read -r dir; do
+      basename "$dir"
+    done | sort >&2
+    return 1
+  fi
+
+  # Exactly one matching command directory - get the full command name
+  local -r full_cmd=$(basename "$matching_dirs")
+
+  echo "Available commands for '$full_cmd'"
+  local -r dashes=$(printf '%*s' "${#full_cmd}" '' | tr ' ' '-')
+  echo "-------------------------${dashes}"
+  find "$commands_dir" \
+    -mindepth 2 \
+    -maxdepth 2 \
+    -type f \
+    -path "${commands_dir}/${full_cmd}/*" \
+    -name "*.sh" | while read -r command_file; do
+    subcommand=$(echo "$command_file" | awk -F/ '{print $NF}' | sed 's/\.sh$//')
+    # first line starting with "##?":
+    description=$(grep -m 1 '^##?' "$command_file" | sed 's/^##? *//')
+    echo -e "$subcommand\t-- $description"
+  done | sort | column -t -s $'\t'
 }
 
 show_cli_help() {

--- a/core/cli_root/cli_init.sh
+++ b/core/cli_root/cli_init.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 # Helper functions used by the CLI directly, and only by the CLI. No command should use these functions.
 
+print_error() {
+  # Print an error message in red.
+  #
+  # Usage:
+  #   print_error <message>
+  local -r message=$1
+  local -r no_color='\x1b[0m'
+  local -r color_red='\x1b[31m'
+  echo >&2 -e "${color_red}ERROR:${no_color} ${message}"
+}
+
 run_command() {
   # Run CLI command.
   #
@@ -51,13 +62,12 @@ run_command() {
     -name "${cmd2}*.sh")
 
   local -r no_color='\x1b[0m'
-  local -r color_red='\x1b[31m'
   local -r color_blue='\x1b[34m'
 
   if [[ -z $command_path ]]; then
     # The command was not found.
     local -r asterisk="${color_blue}*${no_color}"
-    echo >&2 -e "${color_red}ERROR:${no_color} It was not possible to find the command '${cmd1} ${cmd2}'."
+    print_error "It was not possible to find the command '${cmd1} ${cmd2}'."
     echo >&2 -e "       Make sure that the following path exists:"
     echo >&2 -e "         '${commands_dir}/${cmd1}${asterisk}/${cmd2}${asterisk}.sh'"
     echo >&2 -e "       ('${asterisk}' denotes 0 or more characters in the path above)"
@@ -74,7 +84,7 @@ run_command() {
       # Example: 'git check' and 'git checkout' (cm1='git', cmd='check')
       "$command_path_exact" "${cmd_args[@]}"
     else
-      echo >&2 -e "${color_red}ERROR:${no_color} It was not possible to distinguish the commands."
+      print_error "It was not possible to distinguish the commands."
       echo >&2
       echo >&2 "Ambiguous commands"
       echo >&2 "------------------"

--- a/core/cli_root/cli_init.sh
+++ b/core/cli_root/cli_init.sh
@@ -165,10 +165,18 @@ EOF
       basename "$dir"
     done | sort >&2
     return 1
+  elif [[ -n $matching_dir_exact ]]; then
+    local -r selected_dir=$matching_dir_exact
+  elif [[ $matching_count -eq 1 ]]; then
+    local -r selected_dir=$matching_dirs
+  else
+    # This should not happen, but just in case
+    print_error "An unexpected error occurred while listing commands. Matching directories: $matching_dirs"
+    return 1
   fi
 
   # Exactly one matching command directory - get the full command name
-  local -r full_cmd=$(basename "$matching_dirs")
+  local -r full_cmd=$(basename "$selected_dir")
 
   echo "Available commands for '$full_cmd'"
   local -r dashes=$(printf '%*s' "${#full_cmd}" '' | tr ' ' '-')

--- a/core/cli_root/cli_init.sh
+++ b/core/cli_root/cli_init.sh
@@ -86,8 +86,8 @@ run_command() {
     else
       print_error "It was not possible to distinguish the commands."
       echo >&2
-      echo >&2 "Ambiguous commands"
-      echo >&2 "------------------"
+      echo >&2 "Multiple matches found"
+      echo >&2 "----------------------"
       echo "$command_path" |
         sed "s:${commands_dir}/:: ; s:\.sh$::" |
         tr '/' ' ' |
@@ -112,6 +112,7 @@ list_commands() {
   local -r version_description="Show the CLI version."
 
   if [[ -z $cmd ]]; then
+    # No command specified - list all commands
     echo "Available commands"
     echo "------------------"
     {

--- a/core/cli_root/cli_init.sh
+++ b/core/cli_root/cli_init.sh
@@ -79,7 +79,7 @@ run_command() {
     "$command_path" "${cmd_args[@]}"
   else
     # More than one command was found.
-    local -r command_path_exact=$(echo "$command_path" | grep "${cmd2}.sh$")
+    local -r command_path_exact=$(echo "$command_path" | grep "${cmd2}.sh$" || :)
     if [[ -n $command_path_exact ]]; then # 'cmd2' is a substring of another command, but it's an exact match of an existing command
       # Example: 'git check' and 'git checkout' (cm1='git', cmd='check')
       "$command_path_exact" "${cmd_args[@]}"

--- a/core/helpers/files.sh
+++ b/core/helpers/files.sh
@@ -137,6 +137,7 @@ yaml2json() {
 
   if ! python3 -c 'import yaml' &>/dev/null; then
     exit_with_error "PyYAML is not installed (Python package \"yaml\"); cannot convert '$file' to JSON."
+    return 1 # just in case 'exit_with_error' does not exit the script
   fi
 
   local -r code='import sys, yaml, json; json.dump(yaml.safe_load(sys.stdin), sys.stdout, indent=2)'

--- a/core/helpers/python.sh
+++ b/core/helpers/python.sh
@@ -42,7 +42,7 @@ ipynb_cleanmetadata() {
   # Use a temporary file to avoid truncating the output on `jq` failure
   local -r tmp_file="$(mktemp "${output_dir}/.ipynb_cleanmetadata.XXXXXX")"
 
-  if jq --indent 1 '.cells[].metadata = {}' "$file" >"$tmp_file"; then
+  if jq --indent 1 '.cells |= map(.metadata = {})' "$file" >"$tmp_file"; then
     mv "$tmp_file" "$output_file"
   else
     rm -f "$tmp_file"

--- a/tests/core/cli_root/test_autocomplete_helpers.sh
+++ b/tests/core/cli_root/test_autocomplete_helpers.sh
@@ -339,7 +339,7 @@ EOF
 }
 
 test__mycli_extract_arguments_with_descriptions() {
-  local result expected
+  local result expected help_with_path_in_options
 
   help_with_path_in_options=$(
     cat <<-EOF

--- a/tests/core/helpers/test_python.sh
+++ b/tests/core/helpers/test_python.sh
@@ -171,7 +171,7 @@ JSON
 
   # Empty cells array still produces a valid top-level notebook object
   local empty_ipynb_content empty_expected
-  tmp_file=$(mktemp /tmp/test-ipynb-XXXXXX)
+  tmp_file="$(mktemp /tmp/test-ipynb-XXXXXX)"
   empty_ipynb_content=$(
     cat <<'JSON'
 {

--- a/tests/core/helpers/test_python.sh
+++ b/tests/core/helpers/test_python.sh
@@ -168,6 +168,35 @@ JSON
   assertEquals "$input_content" "$ipynb_content"
   assertNotEquals "$input_content" "$result"
   assertEquals "$expected" "$result"
+
+  # Empty cells array still produces a valid top-level notebook object
+  local empty_ipynb_content empty_expected
+  tmp_file=$(mktemp /tmp/test-ipynb-XXXXXX)
+  empty_ipynb_content=$(
+    cat <<'JSON'
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}
+JSON
+  )
+  empty_expected=$(
+    cat <<'JSON'
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}
+JSON
+  )
+  echo "$empty_ipynb_content" >"$tmp_file"
+  ipynb_cleanmetadata "$tmp_file"
+  result=$(cat "$tmp_file")
+  rm -f "$tmp_file"
+  assertEquals "$empty_expected" "$result"
 }
 
 oneTimeSetUp() {


### PR DESCRIPTION
Also:
- Treat case when `grep` does not match
- Add variable definition
- Add unit test for empty jupyter notebook
- Add "return 1" in case the error function doesn't exit
- Add `print_error` function
- Improve logs and comment
- Simplify if-else
